### PR TITLE
Enhance box extraction to handle 3D MRC data by squeezing to 2D

### DIFF
--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -78,19 +78,23 @@ def extract_box(
             # Verify that this is a 2D image
             # Check and handle data dimensionality
             original_shape = mrc.data.shape
+            logger.debug(f"Original data has shape {original_shape}")
+            
+            # Create a local variable for the data to avoid modifying mrc.data
+            data = mrc.data
+            
+            # Try to squeeze the data to handle dimensions of size 1
             if len(original_shape) != 2:
-                logger.debug(f"Original data has shape {original_shape}")
-                # Try to squeeze the data to handle dimensions of size 1
-                mrc.data = mrc.data.squeeze()
+                data = data.squeeze()
                 # Verify that the squeezed result is 2D
-                if len(mrc.data.shape) != 2:
+                if len(data.shape) != 2:
                     raise ValueError(
                         f"Cannot convert data to 2D image. Original shape: {original_shape}, "
-                        f"after squeeze: {mrc.data.shape}"
+                        f"after squeeze: {data.shape}"
                     )
-                logger.debug(f"Squeezed data to shape {mrc.data.shape}")
-
-            image_height, image_width = mrc.data.shape
+                logger.debug(f"Squeezed data to shape {data.shape}")
+            
+            image_height, image_width = data.shape
             logger.debug(f"Image dimensions: {image_width} x {image_height}")
 
             # Calculate box boundaries

--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -76,14 +76,19 @@ def extract_box(
     try:
         with mrcfile.open(mrc_path, mode="r", permissive=True) as mrc:
             # Verify that this is a 2D image
-            if len(mrc.data.shape) ==3:
-                # If the data is 3D, squeeze it to 2D
+            # Check and handle data dimensionality
+            original_shape = mrc.data.shape
+            if len(original_shape) != 2:
+                logger.debug(f"Original data has shape {original_shape}")
+                # Try to squeeze the data to handle dimensions of size 1
                 mrc.data = mrc.data.squeeze()
-            elif len(mrc.data.shape) != 2:
-                # If the data is not 2D, raise an error
-                raise ValueError(
-                    f"Expected 2D image, but got {len(mrc.data.shape)}D data with shape {mrc.data.shape}"
-                )
+                # Verify that the squeezed result is 2D
+                if len(mrc.data.shape) != 2:
+                    raise ValueError(
+                        f"Cannot convert data to 2D image. Original shape: {original_shape}, "
+                        f"after squeeze: {mrc.data.shape}"
+                    )
+                logger.debug(f"Squeezed data to shape {mrc.data.shape}")
 
             image_height, image_width = mrc.data.shape
             logger.debug(f"Image dimensions: {image_width} x {image_height}")

--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -88,14 +88,23 @@ def extract_box(
                 # Already 2D, no need to squeeze
                 logger.debug("Input is already a 2D image")
             elif len(original_shape) == 3:
-                # Try to squeeze 3D data to 2D
-                data = data.squeeze(axis=0)
-                if len(data.shape) != 2:
+                # Find singleton dimensions (dimensions with size 1)
+                singleton_axes = [i for i, size in enumerate(original_shape) if size == 1]
+                
+                if len(singleton_axes) > 0:
+                    # Squeeze all singleton dimensions
+                    data = data.squeeze()
+                    if len(data.shape) != 2:
+                        raise ValueError(
+                            f"Cannot convert 3D data to 2D image. Original shape: {original_shape}, "
+                            f"after squeeze: {data.shape}. Need exactly one singleton dimension."
+                        )
+                    logger.debug(f"Squeezed 3D data to 2D shape {data.shape}")
+                else:
                     raise ValueError(
-                        f"Cannot convert 3D data to 2D image. Original shape: {original_shape}, "
-                        f"after squeeze: {data.shape}. One dimension must be of size 1."
+                        f"Cannot convert 3D data to 2D image. Original shape: {original_shape}. "
+                        f"No singleton dimensions found."
                     )
-                logger.debug(f"Squeezed 3D data to 2D shape {data.shape}")
             else:
                 raise ValueError(
                     f"Unsupported data dimensionality: {original_shape}. Only 2D images or 3D volumes with one dimension of size 1 are supported."

--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -80,20 +80,18 @@ def extract_box(
             original_shape = mrc.data.shape
             logger.debug(f"Original data has shape {original_shape}")
             
-            # Create a local variable for the data to avoid modifying mrc.data
-            image_data = mrc.data.copy()
-            
             # Handle data dimensionality
             if len(original_shape) == 2:
-                # Already 2D, no need to squeeze
+                # Already 2D, use mrc.data directly
                 logger.debug("Input is already a 2D image")
+                image_data = mrc.data
             elif len(original_shape) == 3:
                 # Find singleton dimensions (dimensions with size 1)
                 singleton_axes = [i for i, size in enumerate(original_shape) if size == 1]
                 
                 if len(singleton_axes) == 1:
                     # If exactly one singleton dimension, safe to squeeze all
-                    image_data = np.squeeze(image_data)
+                    image_data = np.squeeze(mrc.data.copy())
                     logger.debug(f"Squeezed 3D data to 2D shape {image_data.shape}")
                 elif len(singleton_axes) > 1:
                     # Try squeezing each singleton dimension to see if it produces a 2D result

--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -89,7 +89,7 @@ def extract_box(
                 logger.debug("Input is already a 2D image")
             elif len(original_shape) == 3:
                 # Try to squeeze 3D data to 2D
-                data = data.squeeze()
+                data = data.squeeze(axis=0)
                 if len(data.shape) != 2:
                     raise ValueError(
                         f"Cannot convert 3D data to 2D image. Original shape: {original_shape}, "

--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -83,16 +83,23 @@ def extract_box(
             # Create a local variable for the data to avoid modifying mrc.data
             data = mrc.data
             
-            # Try to squeeze the data to handle dimensions of size 1
-            if len(original_shape) != 2:
+            # Handle data dimensionality
+            if len(original_shape) == 2:
+                # Already 2D, no need to squeeze
+                logger.debug("Input is already a 2D image")
+            elif len(original_shape) == 3:
+                # Try to squeeze 3D data to 2D
                 data = data.squeeze()
-                # Verify that the squeezed result is 2D
                 if len(data.shape) != 2:
                     raise ValueError(
-                        f"Cannot convert data to 2D image. Original shape: {original_shape}, "
-                        f"after squeeze: {data.shape}"
+                        f"Cannot convert 3D data to 2D image. Original shape: {original_shape}, "
+                        f"after squeeze: {data.shape}. One dimension must be of size 1."
                     )
-                logger.debug(f"Squeezed data to shape {data.shape}")
+                logger.debug(f"Squeezed 3D data to 2D shape {data.shape}")
+            else:
+                raise ValueError(
+                    f"Unsupported data dimensionality: {original_shape}. Only 2D images or 3D volumes with one dimension of size 1 are supported."
+                )
             
             image_height, image_width = data.shape
             logger.debug(f"Image dimensions: {image_width} x {image_height}")

--- a/mrc_box_extractor.py
+++ b/mrc_box_extractor.py
@@ -76,7 +76,11 @@ def extract_box(
     try:
         with mrcfile.open(mrc_path, mode="r", permissive=True) as mrc:
             # Verify that this is a 2D image
-            if len(mrc.data.shape) != 2:
+            if len(mrc.data.shape) ==3:
+                # If the data is 3D, squeeze it to 2D
+                mrc.data = mrc.data.squeeze()
+            elif len(mrc.data.shape) != 2:
+                # If the data is not 2D, raise an error
                 raise ValueError(
                     f"Expected 2D image, but got {len(mrc.data.shape)}D data with shape {mrc.data.shape}"
                 )


### PR DESCRIPTION
Currently if the mrc file has dimensions ==3, it will squeeze it to 2 and fixes the error.

## Summary by Sourcery

Enhancements:
- Automatically squeeze 3D MRC data to 2D to support box extraction